### PR TITLE
Search fix

### DIFF
--- a/gsemantique/data/search.py
+++ b/gsemantique/data/search.py
@@ -57,9 +57,9 @@ class Finder:
                 logger.warn(
                     "AoI consists of multiple polygons. They will be dissolved."
                 )
-                self.aoi = aoi.to_crs(4326).dissolve().geometry[0]
+                self.aoi = aoi.to_crs(4326).dissolve().geometry.iloc[0]
             else:
-                self.aoi = aoi.to_crs(4326).geometry[0]
+                self.aoi = aoi.to_crs(4326).geometry.iloc[0]
         elif isinstance(aoi, shapely.geometry.polygon.Polygon):
             self.aoi = aoi
         else:


### PR DESCRIPTION
#### Description

This PR fixes an AoI parsing issue in cases where a geopandas GeoDataFrame is passed as an AoI input to `Finder()`. To get the first entry in the GeoDataFrame .iloc[0] should be used instead of .loc[0].

#### Type of change

Select one or more relevant options:

- [x] Bug fix (change which fixes a bug reported in a specific issue)
- [ ] New feature (change which adds a feature requested in a specific issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors
