### PR TITLE
preview 0.40.7 (deps: fixing numpy req for colab)

### DIFF
--- a/demo/basics_data.ipynb
+++ b/demo/basics_data.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +24,7 @@
     "    except ImportError:\n",
     "      !git clone https://github.com/Sen2Cube-at/gsemantique.git\n",
     "      !cd gsemantique && pip install .\n",
+    "      !pip install numpy==1.23.5 --force \n",
     "    # change working directory\n",
     "    demo_dir = \"gsemantique/demo\"\n",
     "    import os\n",

--- a/demo/basics_processing.ipynb
+++ b/demo/basics_processing.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +24,7 @@
     "    except ImportError:\n",
     "      !git clone https://github.com/Sen2Cube-at/gsemantique.git\n",
     "      !cd gsemantique && pip install .\n",
+    "      !pip install numpy==1.23.5 --force \n",
     "    # change working directory\n",
     "    demo_dir = \"gsemantique/demo\"\n",
     "    import os\n",

--- a/demo/example_clouds.ipynb
+++ b/demo/example_clouds.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,6 +31,7 @@
     "    except ImportError:\n",
     "      !git clone https://github.com/Sen2Cube-at/gsemantique.git\n",
     "      !cd gsemantique && pip install .\n",
+    "      !pip install numpy==1.23.5 --force \n",
     "    # change working directory\n",
     "    demo_dir = \"gsemantique/demo\"\n",
     "    import os\n",

--- a/demo/example_forests.ipynb
+++ b/demo/example_forests.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,8 +31,9 @@
     "    except ImportError:\n",
     "      !git clone https://github.com/Sen2Cube-at/gsemantique.git\n",
     "      !cd gsemantique && pip install .\n",
+    "      !pip install numpy==1.23.5 --force \n",
     "      # re-install latest version of semantique with semantic temporal filter evaluation \n",
-    "      !pip install --upgrade --no-deps --force-reinstall git+https://github.com/fkroeber/semantique.git@latest \n",
+    "      !pip install --upgrade --no-deps --force-reinstall git+https://github.com/fkroeber/semantique.git@latest\n",
     "    # change working directory\n",
     "    demo_dir = \"gsemantique/demo\"\n",
     "    import os\n",


### PR DESCRIPTION
#### Description

Google Colab has some pre-installed libraries like numpy. When running the demo notebooks on Google Colab, an incompatible version of numpy may cause an error, such as [AttributeError: module 'numpy.linalg._umath_linalg' has no attribute '_ilp64'](https://stackoverflow.com/questions/77451004/attributeerror-module-numpy-linalg-umath-linalg-has-no-attribute-ilp64). A workaround is to fix the numpy version for Google Colab environments beyond the loose requirements as specified in setup.py.

#### Type of change

Select one or more relevant options:

- [x] Bug fix (change which fixes a bug reported in a specific issue)
- [ ] New feature (change which adds a feature requested in a specific issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improved documentation for existing functionality in the package)
- [ ] Repository update (change related to non-package files or structures in the GitHub repository)

#### Checklist:

- [x] I have read and understood the [contributor guidelines](../CONTRIBUTING.md) of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I ran all [demo notebooks](../demo) locally and there where no errors
